### PR TITLE
use new google maps api url and allow specifying the gmaps api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,19 @@ Hoping to release this open source Mondo online banking client once Mondo become
 
 ```
 <?php
-	// your client id
-	$clientid = 'YOUR_CLIENT_ID_HERE';
-	// your client secret
-	$clientsecret = 'YOUR_CLIENT_SECRET_HERE';
-	// root url without the trailing slash!
-	$rooturl = 'http://yourdomain.com';
-	// set the api auth root url - *you don't need to touch this*
-	$api_auth_root = 'https://auth.getmondo.co.uk';
-	// api root url - *you don't need to touch this*
-	$api_root = 'https://api.getmondo.co.uk';
+    // your client id
+    $clientid = 'YOUR_CLIENT_ID_HERE';
+    // your client secret
+    $clientsecret = 'YOUR_CLIENT_SECRET_HERE';
+    // root url without the trailing slash!
+    $rooturl = 'http://yourdomain.com';
+
+    // Google maps API key
+    $google_maps_api_key = 'YOUR_API_KEY';
+
+    // set the api auth root url - *you don't need to touch this*
+    $api_auth_root = 'https://auth.getmondo.co.uk';
+    // api root url - *you don't need to touch this*
+    $api_root = 'https://api.getmondo.co.uk';
 ?>
 ```

--- a/map.php
+++ b/map.php
@@ -68,7 +68,7 @@
 			$average = $total / $i;
 			
 		?>
-		<script src="https://maps.google.com/maps/api/js?sensor=true&.js"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=<?php print $google_maps_api_key; ?>"></script>
 		<script src="https://rawgit.com/HPNeo/gmaps/master/gmaps.js"></script>
 		<script>
 			var map = new GMaps({


### PR DESCRIPTION
First of all, thanks for the great php dashboard! 
When I first setup mondoweb the map wouldn't load (would get some default grey map tiles) and there were errors in the console about not having the google maps api key set.

After doing a bit of digging the map started working again as soon as I changed the url to the new maps.googleapis.com url. 
I have also created a google maps api key and the errors about 'NoApiKeys' has disappeared. While the key is not mandatory, Google recommends setting it. I have added an extra variable in settings.php for it.
A key can be created here: https://developers.google.com/maps/documentation/javascript/get-api-key

I also removed 'sensor=true' from the url as that is not supported any more and it throws a warning in console:
Google Maps API warning: SensorNotRequired https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required

I've only just started contributing back to projects, so I'm practicing with smaller commits :) 
